### PR TITLE
Support Laravel 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [  8.0, 8.1, 8.2 ]
-        laravel: [ 9.*, 10.* ]
+        laravel: [ 8.*, 9.*, 10.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
           - laravel: 8.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ jobs:
         laravel: [ 9.*, 10.* ]
         dependency-version: [ prefer-lowest, prefer-stable ]
         include:
+          - laravel: 8.*
+            testbench: 6.*
+
           - laravel: 9.*
             testbench: 7.*
 
@@ -25,6 +28,11 @@ jobs:
             testbench: 8.*
 
         exclude:
+          # PHP 8.1 requires Laravel 8.65, so skip lowest
+          - laravel: 8.*
+            php: 8.1
+            dependency-version: prefer-lowest
+
             # PHP 8.2 requires Laravel 9.33 at least, so skip lowest
           - laravel: 9.*
             php: 8.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,9 +28,8 @@ jobs:
             testbench: 8.*
 
         exclude:
-          # PHP 8.1 requires Laravel 8.65, so skip lowest
+          # Laravel 8 lowest isn't compatible with newer PHP versions
           - laravel: 8.*
-            php: 8.1
             dependency-version: prefer-lowest
 
             # PHP 8.2 requires Laravel 9.33 at least, so skip lowest

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.0|^10",
-        "illuminate/cache": "^9.0|^10",
-        "illuminate/console": "^9.0|^10"
+        "illuminate/support": "^8.0|^9.0|^10",
+        "illuminate/cache": "^8.0|^9.0|^10",
+        "illuminate/console": "^8.0|^9.0|^10"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",

--- a/src/Arbiter.php
+++ b/src/Arbiter.php
@@ -7,7 +7,7 @@ namespace Hammerstone\Flaky;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
-use Spatie\Macroable\Macroable;
+use Illuminate\Support\Traits\Macroable;
 
 class Arbiter
 {

--- a/src/FlakyCommand.php
+++ b/src/FlakyCommand.php
@@ -7,7 +7,7 @@ namespace Hammerstone\Flaky;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Spatie\Macroable\Macroable;
+use Illuminate\Support\Traits\Macroable;
 
 /**
  * @mixin Flaky


### PR DESCRIPTION
Support Laravel 8 and fix a few references to Spatie's macroable trait instead of Laravel's.