### PR TITLE
Fix mutexes

### DIFF
--- a/src/FlakyCommand.php
+++ b/src/FlakyCommand.php
@@ -7,6 +7,7 @@ namespace Hammerstone\Flaky;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Traits\Macroable;
 
 /**
@@ -57,7 +58,7 @@ class FlakyCommand
     protected function isScheduledCommand()
     {
         // See the FlakyServiceProvider to see where this is coming from.
-        return Arr::get($_ENV, 'IS_SCHEDULED', 0) === '1';
+        return Env::get('IS_SCHEDULED') === '1';
     }
 
     protected function hashInput()

--- a/src/Providers/FlakyServiceProvider.php
+++ b/src/Providers/FlakyServiceProvider.php
@@ -5,7 +5,8 @@
 
 namespace Hammerstone\Flaky\Providers;
 
-use Illuminate\Console\Events\ScheduledTaskStarting;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 
@@ -15,11 +16,12 @@ class FlakyServiceProvider extends ServiceProvider
     {
         // $this->mergeConfigFrom(__DIR__ . '/../../config/flaky.php', 'flaky');
 
-        Event::listen(function (ScheduledTaskStarting $event) {
-            if ($event->task->command) {
-                // Laravel provides no way to tell if a command is running via the
-                // scheduler, so we just add our own environment variable here.
-                $event->task->command = 'IS_SCHEDULED=1 ' . $event->task->command;
+        Event::listen(function (CommandStarting $event) {
+            // When the schedule is starting we add an ENV variable. That
+            // variable will get propagated down to all spawned commands
+            // via the Symfony Process `getDefaultEnv` method.
+            if ($event->command === 'schedule:run') {
+                Env::getRepository()->set('IS_SCHEDULED', 1);
             }
         });
     }

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -5,9 +5,6 @@
 
 namespace Hammerstone\Flaky\Tests\Unit;
 
-use Illuminate\Console\Events\ScheduledTaskStarting;
-use Illuminate\Console\Scheduling\CacheEventMutex;
-use Illuminate\Console\Scheduling\Event as SchedulingEvent;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -8,6 +8,7 @@ namespace Hammerstone\Flaky\Tests\Unit;
 use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Console\Scheduling\CacheEventMutex;
 use Illuminate\Console\Scheduling\Event as SchedulingEvent;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 
@@ -44,23 +45,27 @@ class CommandTest extends Base
         $this->assertEquals('true', $disabled);
 
         // This gets added by our event listener, which is tested elsewhere.
-        $_ENV['IS_SCHEDULED'] = '1';
+        Env::getRepository()->set('IS_SCHEDULED', 1);
 
         Artisan::call('flaky:scheduled');
         $disabled = trim(Artisan::output());
 
         $this->assertEquals('false', $disabled);
 
-        unset($_ENV['IS_SCHEDULED']);
+        Env::getRepository()->set('IS_SCHEDULED', 0);
     }
 
     /** @test */
-    public function scheduled_command_gets_modified()
+    public function env_var_gets_set()
     {
-        Event::dispatch(new ScheduledTaskStarting(
-            $task = new SchedulingEvent(app(CacheEventMutex::class), 'command')
-        ));
+        $repo = Env::getRepository();
 
-        $this->assertEquals('IS_SCHEDULED=1 command', $task->command);
+        $repo->set('IS_SCHEDULED', 0);
+
+        $this->assertEquals('0', $repo->get('IS_SCHEDULED'));
+
+        Artisan::call('schedule:run');
+
+        $this->assertEquals('1', $repo->get('IS_SCHEDULED'));
     }
 }


### PR DESCRIPTION
Using the old method of prepending `IS_SCHEDULED=1` to the command would create mismatching mutexes with the command is `runInBackground` and has `withoutOverlapping` on.

This fixes that!